### PR TITLE
Avoid saving the qualifiedNameToType for every project context

### DIFF
--- a/src/NoUnmatchedUnit.elm
+++ b/src/NoUnmatchedUnit.elm
@@ -114,7 +114,7 @@ fromProjectToModule =
 fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext
 fromModuleToProject =
     Rule.initContextCreator
-        (\{ qualifiedNameToType } -> { qualifiedNameToType = qualifiedNameToType })
+        (\_ -> { qualifiedNameToType = Dict.empty })
 
 
 expressionVisitor : Node Expression -> ModuleContext -> List (Error {})


### PR DESCRIPTION
Hi there 👋 

Thanks again for this package. I noticed some performance issues when running this package on large codebases and with the latest `elm-review` versions. This PR intends to solve the biggest performance concern (I'm making other PRs for other performance issues).

The `fromModuleToProject` function should create a project context specific to the module that was just reviewed, and not contain data from other modules or (in this case) from the dependencies.

This wasn't a problem until elm-review CLI v2.9.0 which attemps to stringify the project context and save it to the file system, causing the same data to be duplicated over and over for every module.

For instance, if analyzing a project with 1000 modules, we will end up copying the stringified data from the dependencies 1000 times.

PS: If the CI fails, maybe https://github.com/mthadley/elm-review-unit/pull/3 needs to be merged in first