### PR TITLE
Speed up rule

### DIFF
--- a/src/NoUnmatchedUnit.elm
+++ b/src/NoUnmatchedUnit.elm
@@ -212,7 +212,15 @@ collectDeps rawDeps =
     let
         collectModule : Elm.Docs.Module -> List ( String, Elm.Type.Type )
         collectModule mod =
-            List.map (\value -> ( mod.name ++ "." ++ value.name, value.tipe ))
+            List.filterMap
+                (\value ->
+                    case value.tipe of
+                        Elm.Type.Lambda _ _ ->
+                            Just ( mod.name ++ "." ++ value.name, value.tipe )
+
+                        _ ->
+                            Nothing
+                )
                 mod.values
 
         collectHelp : Dependency -> Dict String Elm.Type.Type -> Dict String Elm.Type.Type

--- a/src/NoUnmatchedUnit.elm
+++ b/src/NoUnmatchedUnit.elm
@@ -153,33 +153,7 @@ expressionVisitorWithType tipe args =
         ( Elm.Type.Lambda _ _, _ :: _ ) ->
             []
 
-        ( Elm.Type.Type _ (firstArg :: restArgs), node :: restNodes ) ->
-            expressionVisitorWithType firstArg [ node ]
-                ++ (List.map2 (\ta p -> expressionVisitorWithType ta [ p ]) restArgs restNodes
-                        |> List.concat
-                   )
-
-        ( Elm.Type.Type _ [], _ ) ->
-            []
-
-        ( Elm.Type.Tuple (firstArg :: restArgs), node :: restNodes ) ->
-            expressionVisitorWithType firstArg [ node ]
-                ++ (List.map2 (\ta p -> expressionVisitorWithType ta [ p ])
-                        restArgs
-                        restNodes
-                        |> List.concat
-                   )
-
-        ( Elm.Type.Tuple [], _ ) ->
-            []
-
-        ( Elm.Type.Record _ _, _ ) ->
-            []
-
-        ( Elm.Type.Var _, _ ) ->
-            []
-
-        ( _, [] ) ->
+        _ ->
             []
 
 

--- a/src/NoUnmatchedUnit.elm
+++ b/src/NoUnmatchedUnit.elm
@@ -204,7 +204,7 @@ lookupTypeFromNode context name node =
 
 lookupTypeFromName : ModuleContext -> String -> List String -> Maybe Elm.Type.Type
 lookupTypeFromName context name modulePath =
-    Dict.get (String.join "." <| modulePath ++ [ name ]) context.qualifiedNameToType
+    Dict.get (String.join "." modulePath ++ "." ++ name) context.qualifiedNameToType
 
 
 collectDeps : Dict String Dependency -> Dict String Elm.Type.Type

--- a/src/NoUnmatchedUnit.elm
+++ b/src/NoUnmatchedUnit.elm
@@ -223,14 +223,14 @@ collectDeps rawDeps =
                 )
                 mod.values
 
-        collectHelp : Dependency -> Dict String Elm.Type.Type -> Dict String Elm.Type.Type
-        collectHelp dep deps =
+        collectHelp : a -> Dependency -> Dict String Elm.Type.Type -> Dict String Elm.Type.Type
+        collectHelp _ dep deps =
             Dependency.modules dep
                 |> List.concatMap collectModule
                 |> Dict.fromList
                 |> Dict.union deps
     in
-    List.foldl collectHelp Dict.empty <| Dict.values rawDeps
+    Dict.foldl collectHelp Dict.empty rawDeps
 
 
 declarationVisitor : Node Declaration -> List (Error {})


### PR DESCRIPTION
These are some performance optimizations around the collection of values in the dictionary.

According to the tests and the rule code, we in practice only care about values that are lambdas (if this is a wrong assumption, then some tests are missing), so now we only collect into the project context the list of functions whose type is a lambda, which makes for less data in memory but also faster lookups in the dictionary of values. And we also only pattern match on those lambdas, since we won't have anything else.

I think we could do slightly better but only collection the types which contain a unit somewhere, but I'm not entirely sure about this.

I have also changed the collection of elements to be less wasteful in terms of unnecessary data/computations, but I can put this back the way it was before if you prefer, it's not going to make a large impact.